### PR TITLE
Pip module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+
+dist/
+build/
+manydepth.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,145 @@
+models/
+
+assets/test_sequence_target_costvol_min_multi.jpeg
+assets/test_sequence_target_disp_multi.jpeg
+assets/test_sequence_target_disp_multi.npy
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ href="https://storage.googleapis.com/niantic-lon-static/research/manydepth/manyd
 
 ## pip install
 
-Monodepth2 can be installed through pip 
+Manydepth can be installed through pip 
 ```bash
 pip install git+https://github.com/AdityaNG/manydepth@pip-module
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ href="https://storage.googleapis.com/niantic-lon-static/research/manydepth/manyd
 </p>
 
 
+## pip install
+
+Monodepth2 can be installed through pip 
+```bash
+pip install git+https://github.com/AdityaNG/manydepth@pip-module
+```
+
+Run the webcam demo with :
+```bash
+python -m manydepth
+```
+
+To use the class to create a monodepth2 object as follows : 
+```python
+from manydepth  import manydepth
+md = manydepth()
+# Load in a frame along with previous frame
+depth = md.eval(frame, prev_frame)
+```
+
+
 ## Overview
 
 Cost volumes are commonly used for estimating depths from multiple input views:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ href="https://storage.googleapis.com/niantic-lon-static/research/manydepth/manyd
 
 Manydepth can be installed through pip 
 ```bash
-pip install git+https://github.com/AdityaNG/manydepth@pip-module
+pip install manydepth
 ```
 
 Run the webcam demo with :
@@ -44,6 +44,11 @@ md = manydepth()
 depth = md.eval(frame, prev_frame)
 ```
 
+## Install Latest Version (Might be unstable)
+
+```bash
+pip install git+https://github.com/AdityaNG/manydepth@pip-module
+```
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run the webcam demo with :
 python -m manydepth
 ```
 
-To use the class to create a monodepth2 object as follows : 
+To use the class to create a manydepth2 object as follows : 
 ```python
 from manydepth  import manydepth
 md = manydepth()

--- a/manydepth/__init__.py
+++ b/manydepth/__init__.py
@@ -147,5 +147,5 @@ class manydepth:
 
                 #print("-> Saved output image to {}".format(name_dest_im))
 
-        return colormapped_im
+        return toplot
         

--- a/manydepth/__init__.py
+++ b/manydepth/__init__.py
@@ -1,0 +1,151 @@
+import os
+import numpy as np
+import time
+import PIL.Image as pil
+import torch
+import matplotlib as mpl
+import matplotlib.cm as cm
+
+from .layers import transformation_from_parameters
+from .test_simple import load_and_preprocess_intrinsics, preprocess_image
+from .utils import download_model_if_doesnt_exist, manydepth_models_path, model_subfolder_names, git_dir
+from . import networks
+
+MODEL_NAMES = [
+    "KITTI_MR_640_192",
+    "KITTI_HR_1024_320",
+    "CityScapes_512_192"
+]
+
+class manydepth:
+
+    def __init__(self, model_name=MODEL_NAMES[0], no_cuda=False, intrinsics_json_path=os.path.join(git_dir, 'assets/test_sequence_intrinsics.json'), mode='multi') -> None:
+        assert model_name in MODEL_NAMES, "Invalid Model Name"
+        assert mode in ('multi', 'mono'), "Invalid Model Name"
+
+        self.mode = mode
+        
+        if torch.cuda.is_available() and not no_cuda:
+            self.device = torch.device("cuda")
+            print("GPU Visible")
+        else:
+            self.device = torch.device("cpu")
+            print("GPU not visible; CPU mode")
+        
+        # TODO download_model_if_doesnt_exist
+        download_model_if_doesnt_exist(model_name=model_name)
+        self.model_path = os.path.join(manydepth_models_path, model_name, model_subfolder_names[model_name])
+
+        print("-> Loading model from ", self.model_path)
+
+        # Loading pretrained model
+        print("   Loading pretrained encoder")
+        self.encoder_dict = torch.load(os.path.join(self.model_path, "encoder.pth"), map_location=self.device)
+        self.encoder = networks.ResnetEncoderMatching(18, False,
+                                                input_width=self.encoder_dict['width'],
+                                                input_height=self.encoder_dict['height'],
+                                                adaptive_bins=True,
+                                                min_depth_bin=self.encoder_dict['min_depth_bin'],
+                                                max_depth_bin=self.encoder_dict['max_depth_bin'],
+                                                depth_binning='linear',
+                                                num_depth_bins=96)
+
+        filtered_dict_enc = {k: v for k, v in self.encoder_dict.items() if k in self.encoder.state_dict()}
+        self.encoder.load_state_dict(filtered_dict_enc)
+
+        print("   Loading pretrained decoder")
+        self.depth_decoder = networks.DepthDecoder(num_ch_enc=self.encoder.num_ch_enc, scales=range(4))
+
+        loaded_dict = torch.load(os.path.join(self.model_path, "depth.pth"), map_location=self.device)
+        self.depth_decoder.load_state_dict(loaded_dict)
+
+        print("   Loading pose network")
+        self.pose_enc_dict = torch.load(os.path.join(self.model_path, "pose_encoder.pth"),
+                                map_location=self.device)
+        self.pose_dec_dict = torch.load(os.path.join(self.model_path, "pose.pth"), map_location=self.device)
+
+        self.pose_enc = networks.ResnetEncoder(18, False, num_input_images=2)
+        self.pose_dec = networks.PoseDecoder(self.pose_enc.num_ch_enc, num_input_features=1,
+                                        num_frames_to_predict_for=2)
+
+        self.pose_enc.load_state_dict(self.pose_enc_dict, strict=True)
+        self.pose_dec.load_state_dict(self.pose_dec_dict, strict=True)
+
+        # Setting states of networks
+        self.encoder.eval()
+        self.depth_decoder.eval()
+        self.pose_enc.eval()
+        self.pose_dec.eval()
+        if torch.cuda.is_available():
+            self.encoder.cuda()
+            self.depth_decoder.cuda()
+            self.pose_enc.cuda()
+            self.pose_dec.cuda()
+
+        
+        self.K, self.invK = load_and_preprocess_intrinsics(intrinsics_json_path,
+                                             resize_width=self.encoder_dict['width'],
+                                             resize_height=self.encoder_dict['height'])
+
+        pass
+
+    def eval(self, input_image, source_image):
+        """
+            input_image  -> a test image to predict for
+            source_image -> a previous image in the video sequence
+        """
+
+        input_image, original_size = preprocess_image(input_image, resize_width=self.encoder_dict['width'], resize_height=self.encoder_dict['height'])
+        source_image, _ = preprocess_image(source_image, resize_width=self.encoder_dict['width'], resize_height=self.encoder_dict['height'])
+        
+        
+        
+        with torch.no_grad():
+
+            # Estimate poses
+            pose_inputs = [source_image, input_image]
+            pose_inputs = [self.pose_enc(torch.cat(pose_inputs, 1))]
+            axisangle, translation = self.pose_dec(pose_inputs)
+            pose = transformation_from_parameters(axisangle[:, 0], translation[:, 0], invert=True)
+
+            if self.mode == 'mono':
+                pose *= 0  # zero poses are a signal to the self.encoder not to construct a cost volume
+                source_image *= 0
+
+            # Estimate depth
+            output, lowest_cost, _ = self.encoder(current_image=input_image,
+                                            lookup_images=source_image.unsqueeze(1),
+                                            poses=pose.unsqueeze(1),
+                                            K=self.K,
+                                            invK=self.invK,
+                                            min_depth_bin=self.encoder_dict['min_depth_bin'],
+                                            max_depth_bin=self.encoder_dict['max_depth_bin'])
+
+            output = self.depth_decoder(output)
+
+            sigmoid_output = output[("disp", 0)]
+            sigmoid_output_resized = torch.nn.functional.interpolate(
+                sigmoid_output, original_size, mode="bilinear", align_corners=False)
+            sigmoid_output_resized = sigmoid_output_resized.cpu().numpy()[:, 0]
+
+            # Saving numpy file
+            #directory, filename = os.path.split(args.target_image_path)
+            #output_name = os.path.splitext(filename)[0]
+            #name_dest_npy = os.path.join(directory, "{}_disp_{}.npy".format(output_name, self.mode))
+            #np.save(name_dest_npy, sigmoid_output.cpu().numpy())
+
+            # Saving colormapped depth image and cost volume argmin
+            for plot_name, toplot in (('costvol_min', lowest_cost), ('disp', sigmoid_output_resized)):
+                toplot = toplot.squeeze()
+                normalizer = mpl.colors.Normalize(vmin=toplot.min(), vmax=np.percentile(toplot, 95))
+                mapper = cm.ScalarMappable(norm=normalizer, cmap='magma')
+                colormapped_im = (mapper.to_rgba(toplot)[:, :, :3] * 255).astype(np.uint8)
+                im = pil.fromarray(colormapped_im)
+
+                #name_dest_im = os.path.join(directory, "{}_{}_{}.jpeg".format(output_name, plot_name, self.mode))
+                #im.save(name_dest_im)
+
+                #print("-> Saved output image to {}".format(name_dest_im))
+
+        return colormapped_im
+        

--- a/manydepth/__main__.py
+++ b/manydepth/__main__.py
@@ -1,0 +1,63 @@
+from . import manydepth
+import matplotlib.pyplot as plt
+import os
+from .utils import git_dir
+import subprocess
+
+if __name__=="__main__":
+    # Webcam depth
+    import cv2
+    cap = cv2.VideoCapture(0)
+
+    # Clone the repo to access assets/test_sequence_intrinsics.json
+    
+    if not os.path.isdir(git_dir):
+        command = "git clone https://github.com/AdityaNG/manydepth " + git_dir
+        print(command)
+        res = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).stdout.read()
+        
+    m = manydepth()
+
+    plt.ion()
+    # plt.draw()
+    plt.show(block=False)
+
+    ax1 = plt.subplot(1,2,1)
+    ax2 = plt.subplot(1,2,2)
+
+    old_ret, old_frame = ret, frame = cap.read()
+    while(True):
+        try:
+            # Capture the video frame
+            # by frame
+            ret, frame = cap.read()
+
+            #frame = cv2.imread('monodepth2/assets/test_image.jpg')
+        
+            # Display the resulting frame
+            depth = m.eval(frame, old_frame)
+
+            ax1.imshow(frame)
+            ax2.imshow(depth)
+
+            old_ret, old_frame = ret, old_frame
+            
+            #cv2.imwrite('tmps/frame.png', frame)
+            #cv2.imwrite('tmps/depth.png', depth)
+            #depth.save('depth.jpeg')
+            
+            # the 'q' button is set as the
+            # quitting button you may use any
+            # desired button of your choice
+            #time.sleep(0.01)
+            plt.pause(0.001)
+        except Exception as e:
+            print(e)
+            break
+    
+    plt.show()
+    
+    # After the loop release the cap object
+    cap.release()
+    # Destroy all the windows
+    #cv2.destroyAllWindows()

--- a/manydepth/test_simple.py
+++ b/manydepth/test_simple.py
@@ -15,7 +15,8 @@ import matplotlib.cm as cm
 import torch
 from torchvision import transforms
 
-from manydepth import networks
+#from .networks import ResnetEncoderMatching
+from . import networks
 from .layers import transformation_from_parameters
 
 
@@ -37,6 +38,15 @@ def parse_args():
                              'the source image, e.g. as described in Table 5 of the paper.',
                         required=False)
     return parser.parse_args()
+
+def preprocess_image(image_in, resize_width, resize_height):
+    image = pil.fromarray(image_in).convert('RGB')
+    original_width, original_height = image.size
+    image = image.resize((resize_width, resize_height), pil.LANCZOS)
+    image = transforms.ToTensor()(image).unsqueeze(0)
+    if torch.cuda.is_available():
+        return image.cuda(), (original_height, original_width)
+    return image, (original_height, original_width)
 
 
 def load_and_preprocess_image(image_path, resize_width, resize_height):

--- a/manydepth/utils.py
+++ b/manydepth/utils.py
@@ -3,7 +3,11 @@
 # This software is licensed under the terms of the Monodepth2 licence
 # which allows for non-commercial use only, the full terms of which are made
 # available in the LICENSE file.
-
+from __future__ import absolute_import, division, print_function
+import os
+import hashlib
+import zipfile
+from six.moves import urllib
 
 def readlines(filename):
     """Read all the lines in a text file and return as a list
@@ -40,3 +44,42 @@ def sec_to_hm_str(t):
     """
     h, m, s = sec_to_hm(t)
     return "{:02d}h{:02d}m{:02d}s".format(h, m, s)
+
+manydepth_models_path = os.path.join(os.path.expanduser('~'), '.manydepth_models')
+git_dir = os.path.join(manydepth_models_path, 'manydepth')
+model_subfolder_names = {
+    "KITTI_MR_640_192": "KITTI_MR",
+    "KITTI_HR_1024_320": "KITTI_HR",
+    "CityScapes_512_192": "CityScapes_MR"
+}
+
+def download_model_if_doesnt_exist(model_name):
+    """If pretrained kitti model doesn't exist, download and unzip it
+    """
+    # values are tuples of (<google cloud URL>, <md5 checksum>)
+    download_paths = {
+        "KITTI_MR_640_192": "https://storage.googleapis.com/niantic-lon-static/research/manydepth/models/KITTI_MR.zip",
+        "KITTI_HR_1024_320": "https://storage.googleapis.com/niantic-lon-static/research/manydepth/models/KITTI_HR.zip",
+        "CityScapes_512_192": "https://storage.googleapis.com/niantic-lon-static/research/manydepth/models/CityScapes_MR.zip"
+    }
+
+    if not os.path.exists(manydepth_models_path):
+        os.makedirs(manydepth_models_path)
+
+    model_path = os.path.join(manydepth_models_path, model_name)
+    
+    subfolder_name = model_subfolder_names[model_name]
+
+    # see if we have the model already downloaded...
+    if not os.path.exists(os.path.join(model_path, subfolder_name, "encoder.pth")):
+
+        model_url = download_paths[model_name]
+
+        print("-> Downloading pretrained model to {}".format(model_path + ".zip"))
+        urllib.request.urlretrieve(model_url, model_path + ".zip")
+
+        print("   Unzipping model...")
+        with zipfile.ZipFile(model_path + ".zip", 'r') as f:
+            f.extractall(model_path)
+
+        print("   Model unzipped to {}".format(model_path))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setuptools.setup(
+    name="manydepth",
+    version="0.1.0",
+    packages=['manydepth', 'manydepth.networks'],
+    scripts=[],
+    license='LICENSE',
+    url='https://github.com/AdityaNG/monodepth2',
+    description="[ICCV 2019] Monocular depth estimation from a single image",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    python_requires='>=3.6',
+)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     scripts=[],
     license='LICENSE',
     url='https://github.com/AdityaNG/monodepth2',
-    description="[ICCV 2019] Monocular depth estimation from a single image",
+    description="[CVPR 2021] Self-supervised depth estimation from short sequences",
     long_description=long_description,
     long_description_content_type='text/markdown',
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name="manydepth",
-    version="0.1.0",
+    version="1.0.0",
     packages=['manydepth', 'manydepth.networks'],
     scripts=[],
     license='LICENSE',


### PR DESCRIPTION
Having a pip module of manydepth is useful for people working on projects to be able to quickly install and run. I have implemented the installation flow along with a class as a wrapper for manydepth.

# Installation and Usage
Have added instructions to use the module in the `README.md`, in summary 

```bash
# Installation
pip install git+https://github.com/AdityaNG/manydepth@pip-module
```
```python
# Running
from manydepth  import manydepth
md = manydepth()
# Load in a frame along with previous frame
depth = md.eval(frame, prev_frame)
```

# Class Features
The class manydepth allows users to
- Choose the pre-trained model name
- Downloads and caches model
- Enable /  Disable CUDA usage 
- Pass numpy array as input image
- returns numpy array as output

# Webcam Demo

Added a demo to use the webcam and output the depthmap for the video
```shell
python -m manydepth
```

# Caching
Caching of the models has been moved to `~/.manydepth_models/` to simplify downloading and storing of models into one common directory for the user as opposed to the current-working-directory + `models/` path. This was done my writing to a global variable `manydepth_models_path` in the utils